### PR TITLE
Compatibility update for GraphViz 2.38

### DIFF
--- a/sample-applications/MVC4/GraphVizWrapper-MVC4Sample/Web.config
+++ b/sample-applications/MVC4/GraphVizWrapper-MVC4Sample/Web.config
@@ -17,6 +17,7 @@
     <add key="PreserveLoginUrl" value="true" />
     <add key="ClientValidationEnabled" value="true" />
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
+    <add key="graphVizLocation" value="C:\Program Files (x86)\GraphViz2.38"/>
   </appSettings>
   <system.web>
     <httpRuntime targetFramework="4.5" />

--- a/src/GraphVizWrapper.Tests/App.config
+++ b/src/GraphVizWrapper.Tests/App.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <appSettings>
-    <add key="graphVizLocation" value="c:\Graphviz"/>
+    <add key="graphVizLocation" value="C:\Program Files (x86)\GraphViz2.38"/>
   </appSettings>
 </configuration>

--- a/src/GraphVizWrapper/App.config
+++ b/src/GraphVizWrapper/App.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <appSettings>
-    <add key="graphVizLocation" value="c:\Graphviz"/>
+    <add key="graphVizLocation" value="C:\Program Files (x86)\GraphViz2.38"/>
   </appSettings>
 </configuration>

--- a/src/GraphVizWrapper/GraphGeneration.cs
+++ b/src/GraphVizWrapper/GraphGeneration.cs
@@ -94,7 +94,7 @@ namespace GraphVizWrapper
 
         private string FilePath
         {
-            get { return  GraphvizPath + "/" + this.GetRenderingEngine(this.renderingEngine) + ".exe"; }
+            get { return  GraphvizPath + "/bin/" + this.GetRenderingEngine(this.renderingEngine) + ".exe"; }
         }
 
         #endregion


### PR DESCRIPTION
Updated GraphViz default locations and rendering engine file path to
reflect current GraphViz defaults.