### PR TITLE
Change install.xdt files to insert appSettings if missing

### DIFF
--- a/src/nuget-package/Content/app.config.install.xdt
+++ b/src/nuget-package/Content/app.config.install.xdt
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
-  <appSettings>
-    <add key="graphVizLocation" value="" xdt:Transform="Insert" />
+  <appSettings xdt:Transform="InsertIfMissing">
+    <add key="graphVizLocation" value="" xdt:Transform="InsertIfMissing" xdt:Locator="Match(key)" />
   </appSettings>
 </configuration>

--- a/src/nuget-package/Content/web.config.install.xdt
+++ b/src/nuget-package/Content/web.config.install.xdt
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
-  <appSettings>
-    <add key="graphVizLocation" value="" xdt:Transform="Insert" />
+  <appSettings xdt:Transform="InsertIfMissing">
+    <add key="graphVizLocation" value="" xdt:Transform="InsertIfMissing" xdt:Locator="Match(key)" />
   </appSettings>
 </configuration>


### PR DESCRIPTION
When installing GraphViz.NET in a project that does not have an app.config or web.config file, the following error occurs during installation:

`An error occurred while applying transformation to 'app.config' in project 'App' No element in the source document matches '/configuration/appSettings/add' No element in the source document matches '/configuration/appSettings/add'`

This will prevent complete installation, since the packages.config file will then not be updated to add an entry for GraphViz.NET.

This PR modifies the app.config.install.xdt and web.config.install.xdt files to insert the missing appSettings section in the respective config file if it does not exist and insert the key `graphVizLocation` if it does not exist. This fixes the problem and the package can be installed successfully even in the absence of an appSettings section.

This fixes issue #14.